### PR TITLE
distinguishing between "mean" and "meanRate"

### DIFF
--- a/src/main/java/com/yammer/metrics/reporting/DatadogReporter.java
+++ b/src/main/java/com/yammer/metrics/reporting/DatadogReporter.java
@@ -153,7 +153,7 @@ public class DatadogReporter extends AbstractPollingReporter implements MetricPr
 
     public void processMeter(MetricName name, Metered meter, Long epoch) throws Exception {
         pushCounter(name, meter.count(), epoch);
-        pushGauge(name, meter.meanRate(), epoch, "mean");
+        pushGauge(name, meter.meanRate(), epoch, "meanRate");
         pushGauge(name, meter.oneMinuteRate(), epoch, "1MinuteRate");
         pushGauge(name, meter.fiveMinuteRate(), epoch, "5MinuteRate");
         pushGauge(name, meter.fifteenMinuteRate(), epoch, "15MinuteRate");


### PR DESCRIPTION
Renamed "mean" to "meanRate" in processMeter() to avoid exporting overlapping metrics as pushSummarizable() also exports "mean" and both are called in processTimer().
