### PR TITLE
PROD-211 - Update dropwizard-metrics-datadog to support tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ metrics:
   reporters:
     - type: datadog
       host: <host>
+      tags: <tags>                          # Optional.
       apiKey: <apiKey>
       applicationKey: <applicationKey>      # Optional
       includes:                             # Optional. Defaults to (all).
@@ -44,6 +45,7 @@ metrics:
   reporters:
     - type: datadog
       host: <host>
+      tags: <tags>
       apiKey: <apiKey>
       applicationKey: <applicationKey>      # Optional
       includes:

--- a/dropwizard-metrics-datadog/src/main/java/io/dropwizard/metrics/DatadogReporterFactory.java
+++ b/dropwizard-metrics-datadog/src/main/java/io/dropwizard/metrics/DatadogReporterFactory.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 @JsonTypeName("datadog")
 public class DatadogReporterFactory extends BaseReporterFactory {
@@ -22,11 +23,15 @@ public class DatadogReporterFactory extends BaseReporterFactory {
     @JsonProperty
     private String applicationKey = null;
 
+    @JsonProperty
+    private List<String> tags = null;
+
     @Override
     public ScheduledReporter build(MetricRegistry registry) {
         Datadog datadog = new Datadog(apiKey, applicationKey);
         return DatadogReporter.forRegistry(registry)
                 .withHost(host)
+                .withTags(tags)
                 .filter(getFilter())
                 .convertDurationsTo(getDurationUnit())
                 .convertRatesTo(getRateUnit())

--- a/metrics-datadog/src/main/java/com/codahale/metrics/datadog/Datadog.java
+++ b/metrics-datadog/src/main/java/com/codahale/metrics/datadog/Datadog.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.List;
 
 public class Datadog {
     private final String seriesUrl;
@@ -81,13 +82,13 @@ public class Datadog {
         mapper.writeValue(jsonOut, value);
     }
 
-    public void addGauge(String name, Number value, long timestamp, String host)
+    public void addGauge(String name, Number value, long timestamp, String host, List<String> additionalTags)
             throws IOException {
-        add(new DatadogGauge(name, value, timestamp, host));
+        add(new DatadogGauge(name, value, timestamp, host, additionalTags));
     }
 
-    public void addCounter(String name, Long value, long timestamp, String host)
+    public void addCounter(String name, Long value, long timestamp, String host, List<String> additionalTags)
             throws IOException {
-        add(new DatadogCounter(name, value, timestamp, host));
+        add(new DatadogCounter(name, value, timestamp, host, additionalTags));
     }
 }

--- a/metrics-datadog/src/main/java/com/codahale/metrics/datadog/DatadogReporter.java
+++ b/metrics-datadog/src/main/java/com/codahale/metrics/datadog/DatadogReporter.java
@@ -15,7 +15,9 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.concurrent.TimeUnit;
@@ -26,6 +28,7 @@ public class DatadogReporter extends ScheduledReporter {
     private final Clock clock;
     private final String host;
     private final EnumSet<Expansions> expansions;
+    private final List<String> tags;
     private final MetricNameFormatter metricNameFormatter;
     private static final Logger LOG = LoggerFactory
             .getLogger(DatadogReporter.class);
@@ -38,7 +41,8 @@ public class DatadogReporter extends ScheduledReporter {
                             EnumSet<Expansions> expansions,
                             TimeUnit rateUnit,
                             TimeUnit durationUnit,
-                            MetricNameFormatter metricNameFormatter) {
+                            MetricNameFormatter metricNameFormatter,
+                            List<String> tags) {
         super(metricRegistry,
                 "datadog-reporter",
                 filter,
@@ -47,6 +51,7 @@ public class DatadogReporter extends ScheduledReporter {
         this.clock = clock;
         this.host = host;
         this.expansions = expansions;
+        this.tags = tags;
         this.metricNameFormatter = metricNameFormatter;
         this.datadog = datadog;
     }
@@ -96,43 +101,43 @@ public class DatadogReporter extends ScheduledReporter {
             datadog.addGauge(maybeExpand(Expansions.MAX, name),
                     format(convertDuration(snapshot.getMax())),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.MEAN, name),
                     format(convertDuration(snapshot.getMean())),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.MIN, name),
                     format(convertDuration(snapshot.getMin())),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.STD_DEV, name),
                     format(convertDuration(snapshot.getStdDev())),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.P50, name),
                     format(convertDuration(snapshot.getMedian())),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.P75, name),
                     format(convertDuration(snapshot.get75thPercentile())),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.P95, name),
                     format(convertDuration(snapshot.get95thPercentile())),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.P98, name),
                     format(convertDuration(snapshot.get98thPercentile())),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.P99, name),
                     format(convertDuration(snapshot.get99thPercentile())),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.P999, name),
                     format(convertDuration(snapshot.get999thPercentile())),
                     timestamp,
-                    host);
+                    host, tags);
         } catch (Exception e) {
             LOG.error("Error writing timer", e);
         }
@@ -145,23 +150,23 @@ public class DatadogReporter extends ScheduledReporter {
             datadog.addCounter(maybeExpand(Expansions.COUNT, name),
                     meter.getCount(),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.RATE_1_MINUTE, name),
                     format(convertRate(meter.getOneMinuteRate())),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.RATE_5_MINUTE, name),
                     format(convertRate(meter.getFiveMinuteRate())),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.RATE_15_MINUTE, name),
                     format(convertRate(meter.getFifteenMinuteRate())),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.RATE_MEAN, name),
                     format(convertRate(meter.getMeanRate())),
                     timestamp,
-                    host);
+                    host, tags);
         } catch (Exception e) {
             LOG.error("Error writing meter", e);
         }
@@ -174,47 +179,47 @@ public class DatadogReporter extends ScheduledReporter {
             datadog.addCounter(maybeExpand(Expansions.COUNT, name),
                     histogram.getCount(),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.MAX, name),
                     format(snapshot.getMax()),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.MEAN, name),
                     format(snapshot.getMean()),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.MIN, name),
                     format(snapshot.getMin()),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.STD_DEV, name),
                     format(snapshot.getStdDev()),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.P50, name),
                     format(snapshot.getMedian()),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.P75, name),
                     format(snapshot.get75thPercentile()),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.P95, name),
                     format(snapshot.get95thPercentile()),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.P98, name),
                     format(snapshot.get98thPercentile()),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.P99, name),
                     format(snapshot.get99thPercentile()),
                     timestamp,
-                    host);
+                    host, tags);
             datadog.addGauge(maybeExpand(Expansions.P999, name),
                     format(snapshot.get999thPercentile()),
                     timestamp,
-                    host);
+                    host, tags);
         } catch (Exception e) {
             LOG.error("Error writing histogram", e);
         }
@@ -222,7 +227,7 @@ public class DatadogReporter extends ScheduledReporter {
 
     private void reportCounter(String name, Counter counter, long timestamp) {
         try {
-            datadog.addCounter(name, counter.getCount(), timestamp, host);
+            datadog.addCounter(name, counter.getCount(), timestamp, host, tags);
         } catch (Exception e) {
             LOG.error("Error writing counter", e);
         }
@@ -232,7 +237,7 @@ public class DatadogReporter extends ScheduledReporter {
         final Number value = format(gauge.getValue());
         try {
             if (value != null) {
-                datadog.addGauge(name, value, timestamp, host);
+                datadog.addGauge(name, value, timestamp, host, tags);
             }
         } catch (Exception e) {
             LOG.error("Error writing gauge", e);
@@ -298,6 +303,7 @@ public class DatadogReporter extends ScheduledReporter {
         private TimeUnit rateUnit;
         private TimeUnit durationUnit;
         private MetricFilter filter;
+        private List<String> tags;
         private MetricNameFormatter metricNameFormatter;
 
         public Builder(MetricRegistry registry) {
@@ -307,6 +313,7 @@ public class DatadogReporter extends ScheduledReporter {
             this.rateUnit = TimeUnit.SECONDS;
             this.durationUnit = TimeUnit.MILLISECONDS;
             this.filter = MetricFilter.ALL;
+            this.tags = new ArrayList<String>();
             this.metricNameFormatter = new DefaultMetricNameFormatter();
         }
 
@@ -350,6 +357,11 @@ public class DatadogReporter extends ScheduledReporter {
             return this;
         }
 
+        public Builder withTags(List<String> tags) {
+            this.tags = tags;
+            return this;
+        }
+
         @SuppressWarnings("unused")
         public Builder withMetricNameFormatter(MetricNameFormatter formatter) {
             this.metricNameFormatter = formatter;
@@ -366,7 +378,8 @@ public class DatadogReporter extends ScheduledReporter {
                     this.expansions,
                     this.rateUnit,
                     this.durationUnit,
-                    this.metricNameFormatter);
+                    this.metricNameFormatter,
+                    this.tags);
         }
     }
 }

--- a/metrics-datadog/src/main/java/com/codahale/metrics/datadog/model/DatadogCounter.java
+++ b/metrics-datadog/src/main/java/com/codahale/metrics/datadog/model/DatadogCounter.java
@@ -1,9 +1,11 @@
 package com.codahale.metrics.datadog.model;
 
+import java.util.List;
+
 public class DatadogCounter extends DatadogSeries<Long> {
 
-    public DatadogCounter(String name, Long count, Long epoch, String host) {
-        super(name, count, epoch, host);
+    public DatadogCounter(String name, Long count, Long epoch, String host, List<String> additionalTags) {
+        super(name, count, epoch, host, additionalTags);
     }
 
     public String getType() {

--- a/metrics-datadog/src/main/java/com/codahale/metrics/datadog/model/DatadogGauge.java
+++ b/metrics-datadog/src/main/java/com/codahale/metrics/datadog/model/DatadogGauge.java
@@ -1,9 +1,11 @@
 package com.codahale.metrics.datadog.model;
 
 
+import java.util.List;
+
 public class DatadogGauge extends DatadogSeries<Number> {
-    public DatadogGauge(String name, Number count, Long epoch, String host) {
-        super(name, count, epoch, host);
+    public DatadogGauge(String name, Number count, Long epoch, String host, List<String> additionalTags) {
+        super(name, count, epoch, host, additionalTags);
     }
 
     public String getType() {

--- a/metrics-datadog/src/main/java/com/codahale/metrics/datadog/model/DatadogSeries.java
+++ b/metrics-datadog/src/main/java/com/codahale/metrics/datadog/model/DatadogSeries.java
@@ -20,7 +20,7 @@ public abstract class DatadogSeries<T extends Number> {
     // namespace.metricName[tag1:value1,tag2:value2,etc....]
     private final Pattern tagPattern = Pattern.compile("([\\w\\.]+)\\[([\\w\\W]+)\\]");
 
-    public DatadogSeries(String name, T count, Long epoch, String host) {
+    public DatadogSeries(String name, T count, Long epoch, String host, List<String> additionalTags) {
         this.count = count;
         this.epoch = epoch;
         this.host = host;
@@ -39,6 +39,9 @@ public abstract class DatadogSeries<T extends Number> {
             }
         } else {
             this.name = name.replaceAll("[^a-zA-Z0-9\\.]", "\\_");
+        }
+        if (additionalTags != null) {
+            this.tags.addAll(additionalTags);
         }
     }
 

--- a/metrics-datadog/src/test/java/com/codahale/metrics/datadog/DatadogCounterTest.java
+++ b/metrics-datadog/src/test/java/com/codahale/metrics/datadog/DatadogCounterTest.java
@@ -1,36 +1,48 @@
 package com.codahale.metrics.datadog;
 
 import com.codahale.metrics.datadog.model.DatadogCounter;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
 public class DatadogCounterTest {
+    private static List<String> tags;
+    private static String testTag = "testTag:testValue";
+
+    @BeforeClass
+    public static void setup() {
+        tags = new ArrayList<String>();
+        tags.add(testTag);
+    }
 
     @Test
     public void testSplitNameAndTags() {
         DatadogCounter counter = new DatadogCounter(
-                "test[tag1:value1,tag2:value2,tag3:value3]", 1L, 1234L, "Test Host");
+                "test[tag1:value1,tag2:value2,tag3:value3]", 1L, 1234L, "Test Host", tags);
         List<String> tags = counter.getTags();
 
-        assertEquals(3, tags.size());
+        assertEquals(4, tags.size());
         assertEquals("tag1:value1", tags.get(0));
         assertEquals("tag2:value2", tags.get(1));
         assertEquals("tag3:value3", tags.get(2));
+        assertEquals(testTag, tags.get(3));
     }
 
     @Test
     public void testStripInvalidCharsFromTagsAndNames() {
         DatadogCounter counter = new DatadogCounter(
-                "test.name-with_chars[tag.1:va  lue.1,tag-2:va %lue-2,ta  %# g_3:value_3]", 1L, 1234L, "Test Host");
+                "test.name-with_chars[tag.1:va  lue.1,tag-2:va %lue-2,ta  %# g_3:value_3]", 1L, 1234L, "Test Host", tags);
         List<String> tags = counter.getTags();
 
-        assertEquals(3, tags.size());
+        assertEquals(4, tags.size());
         assertEquals("tag.1:value.1", tags.get(0));
         assertEquals("tag-2:value-2", tags.get(1));
         assertEquals("tag_3:value_3", tags.get(2));
+        assertEquals(testTag, tags.get(3));
 
         assertEquals("test.name_with_chars", counter.getMetric());
     }

--- a/metrics-datadog/src/test/java/com/codahale/metrics/datadog/DatadogGaugeTest.java
+++ b/metrics-datadog/src/test/java/com/codahale/metrics/datadog/DatadogGaugeTest.java
@@ -1,36 +1,49 @@
 package com.codahale.metrics.datadog;
 
 import com.codahale.metrics.datadog.model.DatadogGauge;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
 public class DatadogGaugeTest {
+    private static List<String> tags;
+    private static String testTag = "testTag:testValue";
+
+    @BeforeClass
+    public static void setup() {
+        tags = new ArrayList<String>();
+        tags.add(testTag);
+    }
 
     @Test
     public void testSplitNameAndTags() {
         DatadogGauge gauge = new DatadogGauge(
-                "test[tag1:value1,tag2:value2,tag3:value3]", 1L, 1234L, "Test Host");
+                "test[tag1:value1,tag2:value2,tag3:value3]", 1L, 1234L, "Test Host", tags);
         List<String> tags = gauge.getTags();
 
-        assertEquals(3, tags.size());
+        assertEquals(4, tags.size());
         assertEquals("tag1:value1", tags.get(0));
         assertEquals("tag2:value2", tags.get(1));
         assertEquals("tag3:value3", tags.get(2));
+        assertEquals(testTag, tags.get(3));
+
     }
 
     @Test
     public void testStripInvalidCharsFromTagsAndNames() {
         DatadogGauge gauge = new DatadogGauge(
-                "test.name-with_chars[tag.1:va  lue.1,tag-2:va %lue-2,ta  %# g_3:value_3]", 1L, 1234L, "Test Host");
+                "test.name-with_chars[tag.1:va  lue.1,tag-2:va %lue-2,ta  %# g_3:value_3]", 1L, 1234L, "Test Host", tags);
         List<String> tags = gauge.getTags();
 
-        assertEquals(3, tags.size());
+        assertEquals(4, tags.size());
         assertEquals("tag.1:value.1", tags.get(0));
         assertEquals("tag-2:value-2", tags.get(1));
         assertEquals("tag_3:value_3", tags.get(2));
+        assertEquals(testTag, tags.get(3));
 
         assertEquals("test.name_with_chars", gauge.getMetric());
     }

--- a/metrics-datadog/src/test/java/com/codahale/metrics/datadog/DatadogReporterTest.java
+++ b/metrics-datadog/src/test/java/com/codahale/metrics/datadog/DatadogReporterTest.java
@@ -15,6 +15,8 @@ import org.junit.Test;
 import org.mockito.InOrder;
 
 import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
@@ -36,15 +38,20 @@ public class DatadogReporterTest {
     private final long timestamp = 1000198;
     private final Clock clock = mock(Clock.class);
     private static final String host = "hostname";
+    private static List<String> tags;
+    private static String testTag = "testTag:testValue";
 
     @Before
     public void setUp() {
+        tags = new ArrayList<String>();
+        tags.add(testTag);
         when(clock.getTime()).thenReturn(timestamp * 1000);
         metricsRegistry = new MetricRegistry();
         reporter = DatadogReporter
                 .forRegistry(metricsRegistry)
                 .withHost(host)
                 .withClock(clock)
+                .withTags(tags)
                 .convertRatesTo(TimeUnit.SECONDS)
                 .convertDurationsTo(TimeUnit.MILLISECONDS)
                 .build(datadog);
@@ -62,7 +69,7 @@ public class DatadogReporterTest {
 
         final InOrder inOrder = inOrder(datadog);
         inOrder.verify(datadog).createSeries();
-        inOrder.verify(datadog).addGauge("gauge", (byte) 1, timestamp, host);
+        inOrder.verify(datadog).addGauge("gauge", (byte) 1, timestamp, host, tags);
         inOrder.verify(datadog).endSeries();
         inOrder.verify(datadog).sendSeries();
 
@@ -82,7 +89,7 @@ public class DatadogReporterTest {
 
         final InOrder inOrder = inOrder(datadog);
         inOrder.verify(datadog).createSeries();
-        inOrder.verify(datadog).addGauge("gauge", (short) 1, timestamp, host);
+        inOrder.verify(datadog).addGauge("gauge", (short) 1, timestamp, host, tags);
         inOrder.verify(datadog).endSeries();
         inOrder.verify(datadog).sendSeries();
 
@@ -102,7 +109,7 @@ public class DatadogReporterTest {
 
         final InOrder inOrder = inOrder(datadog);
         inOrder.verify(datadog).createSeries();
-        inOrder.verify(datadog).addGauge("gauge", 1, timestamp, host);
+        inOrder.verify(datadog).addGauge("gauge", 1, timestamp, host, tags);
         inOrder.verify(datadog).endSeries();
         inOrder.verify(datadog).sendSeries();
 
@@ -122,7 +129,7 @@ public class DatadogReporterTest {
 
         final InOrder inOrder = inOrder(datadog);
         inOrder.verify(datadog).createSeries();
-        inOrder.verify(datadog).addGauge("gauge", 1L, timestamp, host);
+        inOrder.verify(datadog).addGauge("gauge", 1L, timestamp, host, tags);
         inOrder.verify(datadog).endSeries();
         inOrder.verify(datadog).sendSeries();
 
@@ -142,7 +149,7 @@ public class DatadogReporterTest {
 
         final InOrder inOrder = inOrder(datadog);
         inOrder.verify(datadog).createSeries();
-        inOrder.verify(datadog).addGauge("gauge", 1.1f, timestamp, host);
+        inOrder.verify(datadog).addGauge("gauge", 1.1f, timestamp, host, tags);
         inOrder.verify(datadog).endSeries();
         inOrder.verify(datadog).sendSeries();
 
@@ -162,7 +169,7 @@ public class DatadogReporterTest {
 
         final InOrder inOrder = inOrder(datadog);
         inOrder.verify(datadog).createSeries();
-        inOrder.verify(datadog).addGauge("gauge", 1.1, timestamp, host);
+        inOrder.verify(datadog).addGauge("gauge", 1.1, timestamp, host, tags);
         inOrder.verify(datadog).endSeries();
         inOrder.verify(datadog).sendSeries();
 
@@ -185,7 +192,7 @@ public class DatadogReporterTest {
 
         final InOrder inOrder = inOrder(datadog);
         inOrder.verify(datadog).createSeries();
-        inOrder.verify(datadog).addCounter("counter", 100L, timestamp, host);
+        inOrder.verify(datadog).addCounter("counter", 100L, timestamp, host, tags);
         inOrder.verify(datadog).endSeries();
         inOrder.verify(datadog).sendSeries();
 
@@ -222,17 +229,17 @@ public class DatadogReporterTest {
 
         final InOrder inOrder = inOrder(datadog);
         inOrder.verify(datadog).createSeries();
-        inOrder.verify(datadog).addCounter("histogram.count", 1L, timestamp, host);
-        inOrder.verify(datadog).addGauge("histogram.max", 2L, timestamp, host);
-        inOrder.verify(datadog).addGauge("histogram.mean", 3.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("histogram.min", 4L, timestamp, host);
-        inOrder.verify(datadog).addGauge("histogram.stddev", 5.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("histogram.p50", 6.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("histogram.p75", 7.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("histogram.p95", 8.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("histogram.p98", 9.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("histogram.p99", 10.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("histogram.p999", 11.0, timestamp, host);
+        inOrder.verify(datadog).addCounter("histogram.count", 1L, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("histogram.max", 2L, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("histogram.mean", 3.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("histogram.min", 4L, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("histogram.stddev", 5.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("histogram.p50", 6.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("histogram.p75", 7.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("histogram.p95", 8.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("histogram.p98", 9.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("histogram.p99", 10.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("histogram.p999", 11.0, timestamp, host, tags);
         inOrder.verify(datadog).endSeries();
         inOrder.verify(datadog).sendSeries();
 
@@ -259,11 +266,11 @@ public class DatadogReporterTest {
 
         final InOrder inOrder = inOrder(datadog);
         inOrder.verify(datadog).createSeries();
-        inOrder.verify(datadog).addCounter("meter.count", 1L, timestamp, host);
-        inOrder.verify(datadog).addGauge("meter.1MinuteRate", 2.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("meter.5MinuteRate", 3.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("meter.15MinuteRate", 4.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("meter.meanRate", 5.0, timestamp, host);
+        inOrder.verify(datadog).addCounter("meter.count", 1L, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("meter.1MinuteRate", 2.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("meter.5MinuteRate", 3.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("meter.15MinuteRate", 4.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("meter.meanRate", 5.0, timestamp, host, tags);
         inOrder.verify(datadog).endSeries();
         inOrder.verify(datadog).sendSeries();
 
@@ -314,21 +321,21 @@ public class DatadogReporterTest {
 
         final InOrder inOrder = inOrder(datadog);
         inOrder.verify(datadog).createSeries();
-        inOrder.verify(datadog).addGauge("timer.max", 100.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("timer.mean", 200.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("timer.min", 300.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("timer.stddev", 400.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("timer.p50", 500.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("timer.p75", 600.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("timer.p95", 700.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("timer.p98", 800.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("timer.p99", 900.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("timer.p999", 1000.0, timestamp, host);
-        inOrder.verify(datadog).addCounter("timer.count", 1L, timestamp, host);
-        inOrder.verify(datadog).addGauge("timer.1MinuteRate", 3.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("timer.5MinuteRate", 4.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("timer.15MinuteRate", 5.0, timestamp, host);
-        inOrder.verify(datadog).addGauge("timer.meanRate", 2.0, timestamp, host);
+        inOrder.verify(datadog).addGauge("timer.max", 100.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("timer.mean", 200.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("timer.min", 300.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("timer.stddev", 400.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("timer.p50", 500.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("timer.p75", 600.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("timer.p95", 700.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("timer.p98", 800.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("timer.p99", 900.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("timer.p999", 1000.0, timestamp, host, tags);
+        inOrder.verify(datadog).addCounter("timer.count", 1L, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("timer.1MinuteRate", 3.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("timer.5MinuteRate", 4.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("timer.15MinuteRate", 5.0, timestamp, host, tags);
+        inOrder.verify(datadog).addGauge("timer.meanRate", 2.0, timestamp, host, tags);
         inOrder.verify(datadog).endSeries();
         inOrder.verify(datadog).sendSeries();
 
@@ -349,6 +356,7 @@ public class DatadogReporterTest {
                 .forRegistry(metricsRegistry)
                 .withHost(host)
                 .withClock(clock)
+                .withTags(tags)
                 .filter(new NameMetricFilter("my.metric"))
                 .build(datadog);
 
@@ -359,11 +367,13 @@ public class DatadogReporterTest {
         inOrder.verify(datadog).addCounter("my.metric.counter",
                 123L,
                 timestamp,
-                host);
+                host,
+                tags);
         inOrder.verify(datadog, never()).addCounter("counter",
                 123L,
                 timestamp,
-                host);
+                host,
+                tags);
         inOrder.verify(datadog).endSeries();
         inOrder.verify(datadog).sendSeries();
 
@@ -392,27 +402,32 @@ public class DatadogReporterTest {
                 .addCounter("java.lang.String.meter.count[with,tags]",
                         0L,
                         timestamp,
-                        host);
+                        host,
+                        tags);
         inOrder.verify(datadog)
                 .addGauge("java.lang.String.meter.1MinuteRate[with,tags]",
                         0.0,
                         timestamp,
-                        host);
+                        host,
+                        tags);
         inOrder.verify(datadog)
                 .addGauge("java.lang.String.meter.5MinuteRate[with,tags]",
                         0.0,
                         timestamp,
-                        host);
+                        host,
+                        tags);
         inOrder.verify(datadog)
                 .addGauge("java.lang.String.meter.15MinuteRate[with,tags]",
                         0.0,
                         timestamp,
-                        host);
+                        host,
+                        tags);
         inOrder.verify(datadog)
                 .addGauge("java.lang.String.meter.meanRate[with,tags]",
                         0.0,
                         timestamp,
-                        host);
+                        host,
+                        tags);
         inOrder.verify(datadog).endSeries();
         inOrder.verify(datadog).sendSeries();
 
@@ -432,6 +447,7 @@ public class DatadogReporterTest {
                 .forRegistry(metricsRegistry)
                 .withClock(clock)
                 .withHost(host)
+                .withTags(tags)
                 .build(dd);
         DatadogReporter reporterMockSendNoHost = DatadogReporter
                 .forRegistry(metricsRegistry)


### PR DESCRIPTION
These code changes provide support for sending additional tags to Datadog.  The code is modeled off of com.codahale.metrics-datadog.